### PR TITLE
fixed postgres call

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,8 @@ services:
     ports:
     - 8084:8084
     depends_on:
-      - mongo
-      - auth-service
+    - mongo
+    - auth-service
   postgres:
     container_name: postgres
     environment:


### PR DESCRIPTION
I´ve added a quick fix for the postgres call. Please check, if it is working on your machines. 

Problem: Postgres service is not ready started when auth-service connects the first time to the DB. The docker-compose depends_on waits for the corresponding container to start, but not for the service in the container. 