### PR TITLE
update ingress api version

### DIFF
--- a/kubernetes/auth-service.yml
+++ b/kubernetes/auth-service.yml
@@ -44,7 +44,7 @@ spec:
   selector:
     app: auth-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/kubernetes/disease-service.yml
+++ b/kubernetes/disease-service.yml
@@ -37,7 +37,7 @@ spec:
   selector:
     app: disease-service
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/kubernetes/frontend.yml
+++ b/kubernetes/frontend.yml
@@ -37,7 +37,7 @@ spec:
   selector:
     app: frontend
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/kubernetes/group-phr-controller.yml
+++ b/kubernetes/group-phr-controller.yml
@@ -44,7 +44,7 @@ spec:
   selector:
     app: group-phr-controller
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/kubernetes/nurse-api.yml
+++ b/kubernetes/nurse-api.yml
@@ -47,7 +47,7 @@ spec:
   selector:
     app: nurse-api
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/kubernetes/phr-manager.yml
+++ b/kubernetes/phr-manager.yml
@@ -44,7 +44,7 @@ spec:
   selector:
     app: phr-manager
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:

--- a/kubernetes/statistics.yml
+++ b/kubernetes/statistics.yml
@@ -42,7 +42,7 @@ spec:
   selector:
     app: statistics
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:


### PR DESCRIPTION
The apiVersion: extensions/v1beta1 has been deprecated; this PR upgrades it to networking.k8s.io/v1